### PR TITLE
Update wayfinder build context to official ar-io repo and pin commit

### DIFF
--- a/local_gateway/docker-compose.yml
+++ b/local_gateway/docker-compose.yml
@@ -194,7 +194,7 @@ services:
   wayfinder:
     image: ar.io/wayfinder-router:main-latest
     build:
-      context: https://github.com/vilenarios/wayfinder-router.git#main
+      context: https://github.com/ar-io/wayfinder-router.git#bdc7912e1b62e7dc5c8ca5678b0211238d028137
       dockerfile: Dockerfile
     volumes:
       - wayfinder_data:/app:rw 


### PR DESCRIPTION
[vilenarios/wayfinder-router](http://github.com/vilenarios/wayfinder-router) has been archived and moved to [ar-io/wayfinder-router](https://github.com/ar-io/wayfinder-router) for official AR.IO maintenance.

Also pins the build to a specific commit SHA for reproducibility, consistent with how all other services in the stack use pinned image digests.

Closes https://github.com/ethlimo/dweb-proxy-api/issues/49