### PR TITLE
feat: resolve TON Site (ADNL) contenthash records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ENS dWeb Gateway API
 
-Backend service API for use with reverse proxies to deploy an HTTP [ENS](https://ens.domains)/[GNS](https://genomedomains.com/) gateway capable of resolving [IPFS](https://docs.ipfs.tech/), [IPNS](https://docs.ipfs.tech/how-to/publish-ipns/), [Arweave](https://www.arweave.org/), [Arweave Name System (ArNS)](https://docs.ar.io/arns/#overview), and [Swarm](https://www.ethswarm.org/) content.
+Backend service API for use with reverse proxies to deploy an HTTP [ENS](https://ens.domains)/[GNS](https://genomedomains.com/) gateway capable of resolving [IPFS](https://docs.ipfs.tech/), [IPNS](https://docs.ipfs.tech/how-to/publish-ipns/), [Arweave](https://www.arweave.org/), [Arweave Name System (ArNS)](https://docs.ar.io/arns/#overview), [Swarm](https://www.ethswarm.org/), and [TON Sites](https://docs.ton.org/participate/web3/dns) content.
 
 Upstream proxies can forward ENS and GNS hostnames for resolution and properly route them to the appropriate storage gateway path and destination via the following response headers (IPFS example below):
 
@@ -26,6 +26,7 @@ __Gateway request flow__
 | `IPFS_KUBO_API_URL` | `undefined` | URL to Kubo `/api/v0/name/resolve` service. This setting performs IPNS name resolution and PeerId conversion to CIDv1 identifiers during the contentHash lookup process. Note, this does not enable or disable IPNS support (as this is performed by the IPFS backend) but rather attempts to use resolved CID values as cache keys as opposed to peerIds. Please read the official IPFS [documentation](https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-name-resolve) for more information. |
 | `ARWEAVE_TARGET`     | `"https://arweave.net"` | Arweave gateway FQDN. |
 | `SWARM_TARGET`     | `"https://api.gateway.ethswarm.org"` | Swarm gateway FQDN. |
+| `TON_TARGET`     | `"http://adnl:8080"` | TON gateway root FQDN. Returned in subdomain format, i.e. `${adnlBase32}.adnl:8080`, so `*.adnl` must resolve to an RLDP-HTTP TON proxy. |
 | `IPFS_TARGET` | `http://localhost:8080` | FQDN of IPFS gateway backend to use for requests. |
 | `REDIS_URL`     | `"redis://127.0.0.1:6379"` | Redis server endpoint. |
 | `CACHE_TTL`     | `"300"`      |   TTL to persist resolved records |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ __Gateway request flow__
 | `ARWEAVE_TARGET`     | `"https://arweave.net"` | Arweave gateway FQDN. |
 | `SWARM_TARGET`     | `"https://api.gateway.ethswarm.org"` | Swarm gateway FQDN. |
 | `TON_TARGET`     | `"http://adnl:8080"` | TON gateway root FQDN. Returned in subdomain format, i.e. `${adnlBase32}.adnl:8080`, so `*.adnl` must resolve to an RLDP-HTTP TON proxy. |
+| `TON_ENABLED`     | `"false"` | Enables TON Site (ADNL) contenthash resolution. |
 | `IPFS_TARGET` | `http://localhost:8080` | FQDN of IPFS gateway backend to use for requests. |
 | `REDIS_URL`     | `"redis://127.0.0.1:6379"` | Redis server endpoint. |
 | `CACHE_TTL`     | `"300"`      |   TTL to persist resolved records |

--- a/local_gateway/caddy/Caddyfile
+++ b/local_gateway/caddy/Caddyfile
@@ -24,3 +24,4 @@ import ./sites/wildcard.Caddyfile
 import ./sites/ipfs.Caddyfile
 import ./sites/arweave.Caddyfile
 import ./sites/swarm.Caddyfile
+import ./sites/adnl.Caddyfile

--- a/local_gateway/caddy/routes/storage-gateways.Caddyfile
+++ b/local_gateway/caddy/routes/storage-gateways.Caddyfile
@@ -73,6 +73,31 @@
 	}
 }
 
+&(adnl-gateway-http) {
+	reverse_proxy {http.vars.gateway} {
+		rewrite {uri}
+		# Strip leaky headers
+		header_up -X-Forwarded-Host
+		header_up -X-Forwarded-For
+		header_up Host {http.vars.adnlhost}
+
+		transport http {
+			dial_timeout 30s
+			response_header_timeout 30s
+			expect_continue_timeout 30s
+			read_timeout 30s
+			write_timeout 30s
+		}
+
+		# Gracefully handle 3xx redirects from upstream
+		# i.e. wikipage.eth/wiki/IBM -> wikipage.eth/wiki/IBM/
+		@redirect3xx status 3xx
+		handle_response @redirect3xx {
+			redir {rp.header.Location} permanent
+		}
+	}
+}
+
 # Router for HTTPS upstreams
 &(ipfs-gateway-https) {
 	reverse_proxy {http.vars.gateway} {
@@ -130,6 +155,33 @@
 		header_up -X-Forwarded-Host
 		header_up -X-Forwarded-For
 		header_up Host localhost
+
+		transport http {
+			tls
+			dial_timeout 30s
+			response_header_timeout 30s
+			expect_continue_timeout 30s
+			read_timeout 30s
+			write_timeout 30s
+			tls_timeout 30s
+		}
+
+		# Gracefully handle 3xx redirects from upstream
+		# i.e. wikipage.eth/wiki/IBM -> wikipage.eth/wiki/IBM/
+		@redirect3xx status 3xx
+		handle_response @redirect3xx {
+			redir {rp.header.Location} permanent
+		}
+	}
+}
+
+&(adnl-gateway-https) {
+	reverse_proxy {http.vars.gateway} {
+		rewrite {uri}
+		# Strip leaky headers
+		header_up -X-Forwarded-Host
+		header_up -X-Forwarded-For
+		header_up Host {http.vars.adnlhost}
 
 		transport http {
 			tls

--- a/local_gateway/caddy/sites/adnl.Caddyfile
+++ b/local_gateway/caddy/sites/adnl.Caddyfile
@@ -1,0 +1,53 @@
+# Site block for local TON Sites (adnl) gateway
+*.adnl.localhost {
+	log {
+		level DEBUG
+		format console
+	}
+
+	bind 0.0.0.0
+	encode gzip zstd
+	tls internal
+	import default-headers
+
+	route * {
+		vars gateway {$TON_GATEWAY_HOST}
+		vars adnlhost {labels.2}.adnl
+		@https_upstream expression `{http.vars.gateway}.endsWith(":443")`
+
+		handle @https_upstream {
+			invoke adnl-gateway-https
+		}
+
+		handle {
+			invoke adnl-gateway-http
+		}
+	}
+}
+
+# Site block for local TON Sites (adnl) gateway without localhost suffix
+*.adnl {
+	log {
+		level DEBUG
+		format console
+	}
+
+	bind 0.0.0.0
+	encode gzip zstd
+	tls internal
+	import default-headers
+
+	route * {
+		vars gateway {$TON_GATEWAY_HOST}
+		vars adnlhost {labels.1}.adnl
+		@https_upstream expression `{http.vars.gateway}.endsWith(":443")`
+
+		handle @https_upstream {
+			invoke adnl-gateway-https
+		}
+
+		handle {
+			invoke adnl-gateway-http
+		}
+	}
+}

--- a/local_gateway/dns/dnsmasq.conf
+++ b/local_gateway/dns/dnsmasq.conf
@@ -1,6 +1,7 @@
 address=/rainbow/172.20.0.55
 address=/wayfinder/172.20.0.58
 address=/bee/172.20.0.59
+address=/adnl/172.20.0.60
 address=/dweb-proxy-api/172.20.0.53
 address=/dns.eth/172.20.0.52
 server=127.0.0.11

--- a/local_gateway/docker-compose.yml
+++ b/local_gateway/docker-compose.yml
@@ -80,6 +80,8 @@ services:
       - SWARM_TARGET=http://bee:1633
       # TON gateway target URL
       - TON_TARGET=${TON_TARGET:-http://adnl:8080}
+      # Enable TON Site (ADNL) contenthash resolution
+      - TON_ENABLED=${TON_ENABLED:-true}
       # How long to keep domain resolution results cached (in seconds)
       - CACHE_TTL=${CACHE_TTL:-300}
       # HTTPS ingress certificate issuance check (not required for local environments)

--- a/local_gateway/docker-compose.yml
+++ b/local_gateway/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - IPFS_GATEWAY_HOST=rainbow:8090
       - ARWEAVE_GATEWAY_HOST=wayfinder:3000
       - SWARM_GATEWAY_HOST=bee:1633
+      - TON_GATEWAY_HOST=${TON_GATEWAY_HOST:-tonutils-proxy:8080}
     volumes:
       - ./caddy:/etc/caddy:ro
       - ./data:/data:Z777
@@ -77,6 +78,8 @@ services:
       - ARWEAVE_TARGET=http://wayfinder:3000
       # Swarm gateway target URL
       - SWARM_TARGET=http://bee:1633
+      # TON gateway target URL
+      - TON_TARGET=${TON_TARGET:-http://adnl:8080}
       # How long to keep domain resolution results cached (in seconds)
       - CACHE_TTL=${CACHE_TTL:-300}
       # HTTPS ingress certificate issuance check (not required for local environments)
@@ -305,6 +308,23 @@ services:
   #  cpu_percent: 5      
   #  mem_limit: 256m      
   #  restart: unless-stopped
+
+  # TON Sites gateway (RLDP-HTTP TON proxy). Must accept host:port Host values.
+  #tonutils-proxy:
+  #  image: <your-tonutils-proxy-image>
+  #  command: ["--addr", "0.0.0.0:8080", "--no-http"]
+  #  networks:
+  #    gateway:
+  #      ipv4_address: 172.20.0.60
+  #  cap_drop:
+  #    - ALL
+  #  read_only: true
+  #  restart: unless-stopped
+  #  expose:
+  #    - "8080"
+  #  dns:
+  #    - 172.20.0.57
+  #  dns_search: []
 
   # Wildcard DNS for subdomain resolution within the network namespace
   wildcard-dns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2233,26 +2233,6 @@
             "integrity": "sha512-L/GoCkQFePjSn4DeVnBNfkGdm2CI8UxTxwgQztcZ1L9aHaFefRD+mTUXxtikk946KwwMHRQJDn38wo1IWtEpSg==",
             "license": "BSD-2-Clause"
         },
-        "node_modules/@ensdomains/content-hash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@ensdomains/content-hash/-/content-hash-3.0.0.tgz",
-            "integrity": "sha512-5ongDPX9qDkemcYZ2rPXsRzCRDneoR2xujm2Tq3u0ZefQa49ZAURVKGqbJdjoL0VIZDfceLkBXekYKqkfrR5Ww==",
-            "license": "MIT",
-            "dependencies": {
-                "@multiformats/sha3": "^2.0.17",
-                "multiformats": "^12.0.1"
-            }
-        },
-        "node_modules/@ensdomains/content-hash/node_modules/multiformats": {
-            "version": "12.1.3",
-            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
-            "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
-            "license": "Apache-2.0 OR MIT",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
         "node_modules/@ensdomains/ens-contracts": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/@ensdomains/ens-contracts/-/ens-contracts-1.7.0.tgz",
@@ -4448,22 +4428,6 @@
                 "node": ">=16.0.0",
                 "npm": ">=7.0.0"
             }
-        },
-        "node_modules/@multiformats/sha3": {
-            "version": "2.0.17",
-            "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-2.0.17.tgz",
-            "integrity": "sha512-7ik6pk178qLO2cpNucgf48UnAOBMkq/2H92DP4SprZOJqM9zqbVaKS7XyYW6UvhRsDJ3wi921fYv1ihTtQHLtA==",
-            "license": "(Apache-2.0 AND MIT)",
-            "dependencies": {
-                "js-sha3": "^0.8.0",
-                "multiformats": "^9.5.4"
-            }
-        },
-        "node_modules/@multiformats/sha3/node_modules/multiformats": {
-            "version": "9.9.0",
-            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-            "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-            "license": "(Apache-2.0 AND MIT)"
         },
         "node_modules/@multiformats/uri-to-multiaddr": {
             "version": "8.1.0",
@@ -13898,7 +13862,8 @@
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
             "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -19727,9 +19692,10 @@
             "version": "5.0.10",
             "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
             "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-            "extraneous": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"
             },
@@ -20675,7 +20641,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@ensdomains/content-hash": "^3.0.0-beta.5",
+                "@ensdomains/content-hash": "^3.1.1",
                 "@ensdomains/ethers-patch-v6": "0.0.4",
                 "@ethlimo/ens-hooks": "0.1.15",
                 "@libp2p/peer-id": "^4.0.9",
@@ -20701,6 +20667,35 @@
                 "tsx": "^4.6.1",
                 "typescript": "^5.1.3"
             }
+        },
+        "packages/dweb-api-resolver/node_modules/@ensdomains/content-hash": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@ensdomains/content-hash/-/content-hash-3.1.1.tgz",
+            "integrity": "sha512-BKB3BtAtfDkSX3DOYsnnTlzAeM55bI0ze7UJhk8TzoxO5/4iHjgPoEHDzjgzCTYJoCOkpFPEDah+gl62e7HJjA==",
+            "license": "MIT",
+            "dependencies": {
+                "@multiformats/sha3": "^4.0.0",
+                "multiformats": "^13.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/dweb-api-resolver/node_modules/@multiformats/sha3": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-4.0.0.tgz",
+            "integrity": "sha512-y/tB2RWyeIhUToaUIYkwZUtGqfGIa3kaTvAMVekvxWJUYaD7YLa7L6O8QYaOblxxc1MMobGwh63kS1NhocRQPw==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "js-sha3": "^0.9.1",
+                "multiformats": "^14.0.0"
+            }
+        },
+        "packages/dweb-api-resolver/node_modules/@multiformats/sha3/node_modules/multiformats": {
+            "version": "14.0.2",
+            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.2.tgz",
+            "integrity": "sha512-sF7F3gBKCyehzIhDwVuTRf79TZ8qWRz5NXwWYBX+4a+n22KcFqqcDYJvZr7tySrI0MhuTBXVOlo3qMTiAHC78g==",
+            "license": "Apache-2.0 OR MIT"
         },
         "packages/dweb-api-resolver/node_modules/chokidar": {
             "version": "3.6.0",
@@ -20761,6 +20756,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "packages/dweb-api-resolver/node_modules/js-sha3": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.3.tgz",
+            "integrity": "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==",
+            "license": "MIT"
         },
         "packages/dweb-api-resolver/node_modules/mocha": {
             "version": "10.8.2",
@@ -20851,7 +20852,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
-                "@ensdomains/content-hash": "^3.0.0-beta.5",
+                "@ensdomains/content-hash": "^3.1.1",
                 "@ethlimo/ens-hooks": "0.1.15",
                 "@libp2p/peer-id": "^4.0.9",
                 "@web3-name-sdk/core": "^0.2.0",
@@ -20883,6 +20884,41 @@
                 "node-mocks-http": "^1.14.1",
                 "url-regex-safe": "^4.0.0"
             }
+        },
+        "packages/dweb-api-server/node_modules/@ensdomains/content-hash": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@ensdomains/content-hash/-/content-hash-3.1.1.tgz",
+            "integrity": "sha512-BKB3BtAtfDkSX3DOYsnnTlzAeM55bI0ze7UJhk8TzoxO5/4iHjgPoEHDzjgzCTYJoCOkpFPEDah+gl62e7HJjA==",
+            "license": "MIT",
+            "dependencies": {
+                "@multiformats/sha3": "^4.0.0",
+                "multiformats": "^13.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/dweb-api-server/node_modules/@multiformats/sha3": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@multiformats/sha3/-/sha3-4.0.0.tgz",
+            "integrity": "sha512-y/tB2RWyeIhUToaUIYkwZUtGqfGIa3kaTvAMVekvxWJUYaD7YLa7L6O8QYaOblxxc1MMobGwh63kS1NhocRQPw==",
+            "license": "Apache-2.0 OR MIT",
+            "dependencies": {
+                "js-sha3": "^0.9.1",
+                "multiformats": "^14.0.0"
+            }
+        },
+        "packages/dweb-api-server/node_modules/@multiformats/sha3/node_modules/multiformats": {
+            "version": "14.0.2",
+            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.2.tgz",
+            "integrity": "sha512-sF7F3gBKCyehzIhDwVuTRf79TZ8qWRz5NXwWYBX+4a+n22KcFqqcDYJvZr7tySrI0MhuTBXVOlo3qMTiAHC78g==",
+            "license": "Apache-2.0 OR MIT"
+        },
+        "packages/dweb-api-server/node_modules/js-sha3": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.3.tgz",
+            "integrity": "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==",
+            "license": "MIT"
         },
         "packages/dweb-api-serviceworker": {
             "version": "1.0.0",

--- a/packages/dweb-api-resolver/package.json
+++ b/packages/dweb-api-resolver/package.json
@@ -11,7 +11,7 @@
     "author": "eth.limo team",
     "license": "MIT",
     "dependencies": {
-        "@ensdomains/content-hash": "^3.0.0-beta.5",
+        "@ensdomains/content-hash": "^3.1.1",
         "@ensdomains/ethers-patch-v6": "0.0.4",
         "@ethlimo/ens-hooks": "0.1.15",
         "@libp2p/peer-id": "^4.0.9",

--- a/packages/dweb-api-resolver/src/resolver/adnl.ts
+++ b/packages/dweb-api-resolver/src/resolver/adnl.ts
@@ -1,0 +1,25 @@
+import { base32 } from "rfc4648";
+
+const crc16Xmodem = (data: Uint8Array): number => {
+  let crc = 0;
+  for (const byte of data) {
+    crc ^= byte << 8;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = crc & 0x8000 ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff;
+    }
+  }
+  return crc;
+};
+
+export const adnlAddressToHostname = (adnlAddress: string): string | null => {
+  if (!/^[0-9a-fA-F]{64}$/.test(adnlAddress)) {
+    return null;
+  }
+  const payload = new Uint8Array(35);
+  payload[0] = 0x2d;
+  payload.set(Buffer.from(adnlAddress, "hex"), 1);
+  const crc = crc16Xmodem(payload.subarray(0, 33));
+  payload[33] = crc >> 8;
+  payload[34] = crc & 0xff;
+  return base32.stringify(payload).slice(1).toLowerCase();
+};

--- a/packages/dweb-api-resolver/src/resolver/index.ts
+++ b/packages/dweb-api-resolver/src/resolver/index.ts
@@ -66,6 +66,14 @@ export async function parseRecord(
       DoHContentIdentifier: cleanPath,
       ensName: hostname,
     };
+  } else if (content.startsWith("adnl://")) {
+    const cleanPath = content.split("adnl://")[1];
+    return {
+      _tag: "Record",
+      codec: "adnl",
+      DoHContentIdentifier: cleanPath,
+      ensName: hostname,
+    };
   } else {
     return null;
   }

--- a/packages/dweb-api-resolver/src/resolver/utils.ts
+++ b/packages/dweb-api-resolver/src/resolver/utils.ts
@@ -213,6 +213,19 @@ export const recordToProxyRecord = async (
         ),
       };
     } else if (record.codec === "adnl") {
+      if (!tonConfig.getEnabled()) {
+        logger.debug("ADNL resolution is disabled", {
+          ...request,
+          origin: "recordToProxyRecord",
+          context: {
+            record,
+          },
+        });
+        return {
+          _tag: "ProxyRecordUnableToRedirect",
+          record: record,
+        };
+      }
       const hostname = adnlAddressToHostname(record.DoHContentIdentifier);
       if (hostname === null) {
         logger.error("ADNL address can not be encoded as a DNS fragment", {

--- a/packages/dweb-api-resolver/src/resolver/utils.ts
+++ b/packages/dweb-api-resolver/src/resolver/utils.ts
@@ -1,6 +1,7 @@
 import { recordNamespaceToUrlHandlerMap } from "./const.js";
 import { ILoggerService } from "dweb-api-types/logger";
 import { arweaveUrlToSandboxSubdomain } from "./arweave.js";
+import { adnlAddressToHostname } from "./adnl.js";
 import { IRequestContext } from "dweb-api-types/request-context";
 import { IRecord } from "dweb-api-types/ens-resolver";
 import { ProxyRecord } from "dweb-api-types/dweb-api-resolver";
@@ -9,6 +10,7 @@ import {
   IConfigurationEnsSocials,
   IConfigurationIpfs,
   IConfigurationSwarm,
+  IConfigurationTon,
 } from "dweb-api-types/config";
 
 export const ensureTrailingSlash = (path: string) => {
@@ -102,7 +104,8 @@ export const recordToProxyRecord = async (
   config: IConfigurationEnsSocials &
     IConfigurationIpfs &
     IConfigurationArweave &
-    IConfigurationSwarm,
+    IConfigurationSwarm &
+    IConfigurationTon,
   logger: ILoggerService,
   record: NonNullable<IRecord>,
 ): Promise<
@@ -114,6 +117,7 @@ export const recordToProxyRecord = async (
   const ipfsConfig = config.getConfigIpfsBackend();
   const arweaveConfig = config.getConfigArweaveBackend();
   const swarmConfig = config.getConfigSwarmBackend();
+  const tonConfig = config.getConfigTonBackend();
   var path = "/";
   var overrideCodecHeader: string | undefined = undefined;
   if (record._tag === "ens-socials-redirect") {
@@ -207,6 +211,29 @@ export const recordToProxyRecord = async (
         XContentPath: ensureTrailingSlash(
           "/bzz/" + record.DoHContentIdentifier,
         ),
+      };
+    } else if (record.codec === "adnl") {
+      const hostname = adnlAddressToHostname(record.DoHContentIdentifier);
+      if (hostname === null) {
+        logger.error("ADNL address can not be encoded as a DNS fragment", {
+          ...request,
+          origin: "recordToProxyRecord",
+          context: {
+            record,
+          },
+        });
+        throw new Error("ADNL address can not be encoded as a DNS fragment");
+      }
+      const backendString = tonConfig.getBackend();
+      const url = new URL(backendString);
+      url.hostname = `${hostname}.${url.hostname}`;
+      const explicitPort =
+        extractExplicitPort(backendString) ||
+        (url.protocol === "https:" ? "443" : "80");
+      return {
+        ...record,
+        XContentLocation: constructUrlWithPort(url, explicitPort),
+        XContentPath: "/",
       };
     }
     //record.codec should be never due to exhaustivity check

--- a/packages/dweb-api-resolver/test/resolver/adnl.spec.ts
+++ b/packages/dweb-api-resolver/test/resolver/adnl.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { adnlAddressToHostname } from "../../src/resolver/adnl.js";
+
+describe("adnlAddressToHostname", () => {
+  it("should encode a 32-byte ADNL address as a 55-character hostname label", () => {
+    expect(
+      adnlAddressToHostname(
+        "61bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5",
+      ),
+    ).to.equal("vq33bk5u3ah5di4qb7iqdbktjrheai47qvtjmxj3yzm2n77n5folewn");
+  });
+
+  it("should encode the all-zero address", () => {
+    expect(
+      adnlAddressToHostname(
+        "0000000000000000000000000000000000000000000000000000000000000000",
+      ),
+    ).to.equal("uaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadi2");
+  });
+
+  it("should encode the all-ff address", () => {
+    expect(
+      adnlAddressToHostname(
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      ),
+    ).to.equal("x777777777777777777777777777777777777777777777777777cno");
+  });
+
+  it("should return null for input that is not 64 hex characters", () => {
+    expect(adnlAddressToHostname("61bd855d")).to.be.null;
+    expect(
+      adnlAddressToHostname(
+        "zzbd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5",
+      ),
+    ).to.be.null;
+    expect(
+      adnlAddressToHostname(
+        "61bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae500",
+      ),
+    ).to.be.null;
+  });
+});

--- a/packages/dweb-api-server/package.json
+++ b/packages/dweb-api-server/package.json
@@ -16,7 +16,7 @@
   "author": "eth.limo team",
   "license": "MIT",
   "dependencies": {
-    "@ensdomains/content-hash": "^3.0.0-beta.5",
+    "@ensdomains/content-hash": "^3.1.1",
     "@ethlimo/ens-hooks": "0.1.15",
     "@libp2p/peer-id": "^4.0.9",
     "@web3-name-sdk/core": "^0.2.0",

--- a/packages/dweb-api-server/src/configuration/index.ts
+++ b/packages/dweb-api-server/src/configuration/index.ts
@@ -14,6 +14,7 @@ import type {
   IDomainQueryConfig,
   IRedisConfig,
   IConfigurationSwarm,
+  IConfigurationTon,
   IConfigurationLogger,
   IConfigurationKubo,
   ICondfigurationDataUrlEndpoint,
@@ -74,6 +75,9 @@ const configuration = {
   },
   swarm: {
     backend: process.env.SWARM_TARGET || "https://api.gateway.ethswarm.org",
+  },
+  ton: {
+    backend: process.env.TON_TARGET || "http://adnl:8080",
   },
   redis: {
     url: process.env.REDIS_URL || "redis://127.0.0.1:6379",
@@ -188,6 +192,7 @@ export class TestConfigurationService implements ServerConfiguration {
     this.configuration.logging.level = "debug";
     this.configuration.swarm.backend = "https://swarm"; //swarm is never actually queried
     this.configuration.arweave.backend = "https://arweave"; //arweave is never actually queried
+    this.configuration.ton.backend = "http://adnl:8080"; //ton is never actually queried
     this.configuration.ens.socialsEndpoint = (ens: string) => {
       return `https://socials.com?name=${ens}`;
     };
@@ -261,6 +266,10 @@ export class TestConfigurationService implements ServerConfiguration {
 
   getConfigSwarmBackend = () => {
     return this.getServerConfiguration().getConfigSwarmBackend();
+  };
+
+  getConfigTonBackend = () => {
+    return this.getServerConfiguration().getConfigTonBackend();
   };
 
   getLoggerConfig = () => {
@@ -533,6 +542,20 @@ export const configurationToIConfigurationSwarm = (config: {
   };
 };
 
+export const configurationToIConfigurationTon = (config: {
+  ton: {
+    backend: string;
+  };
+}): IConfigurationTon => {
+  return {
+    getConfigTonBackend: () => {
+      return {
+        getBackend: () => config.ton.backend,
+      };
+    },
+  };
+};
+
 export const configurationToIConfigurationLogger = (config: {
   logging: {
     level: string;
@@ -662,6 +685,7 @@ export type ServerConfiguration = IConfigurationServerRouter &
   IConfigurationIpfs &
   IConfigurationArweave &
   IConfigurationSwarm &
+  IConfigurationTon &
   IAskEndpointConfig &
   IConfigHostnameSubstitution &
   IConfigurationEthereum &
@@ -697,6 +721,7 @@ export const configurationToServerConfiguration = (
     ...configurationToIConfigurationServerDnsquery(config),
     ...configurationToIConfigurationServerRouter(config),
     ...configurationToIConfigurationSwarm(config),
+    ...configurationToIConfigurationTon(config),
     ...configurationToIConfigurationLogger(config),
     ...configurationToIConfigurationIpfs(config),
     ...configurationToIConfigurationKubo(config),

--- a/packages/dweb-api-server/src/configuration/index.ts
+++ b/packages/dweb-api-server/src/configuration/index.ts
@@ -78,6 +78,7 @@ const configuration = {
   },
   ton: {
     backend: process.env.TON_TARGET || "http://adnl:8080",
+    enabled: process.env.TON_ENABLED === "true" ? true : false,
   },
   redis: {
     url: process.env.REDIS_URL || "redis://127.0.0.1:6379",
@@ -193,6 +194,7 @@ export class TestConfigurationService implements ServerConfiguration {
     this.configuration.swarm.backend = "https://swarm"; //swarm is never actually queried
     this.configuration.arweave.backend = "https://arweave"; //arweave is never actually queried
     this.configuration.ton.backend = "http://adnl:8080"; //ton is never actually queried
+    this.configuration.ton.enabled = true;
     this.configuration.ens.socialsEndpoint = (ens: string) => {
       return `https://socials.com?name=${ens}`;
     };
@@ -545,12 +547,14 @@ export const configurationToIConfigurationSwarm = (config: {
 export const configurationToIConfigurationTon = (config: {
   ton: {
     backend: string;
+    enabled: boolean;
   };
 }): IConfigurationTon => {
   return {
     getConfigTonBackend: () => {
       return {
         getBackend: () => config.ton.backend,
+        getEnabled: () => config.ton.enabled,
       };
     },
   };

--- a/packages/dweb-api-server/src/dnsquery/index.ts
+++ b/packages/dweb-api-server/src/dnsquery/index.ts
@@ -16,6 +16,7 @@ import type { IRequestContext } from "dweb-api-types/request-context";
 import type {
   ICacheConfig,
   IConfigurationLogger,
+  IConfigurationTon,
 } from "dweb-api-types/config";
 import { recordNamespaceToUrlHandlerMap } from "dweb-api-resolver/resolver/const";
 import { punycodeDomainPartsToUnicode } from "dweb-api-resolver/punycodeConverter";
@@ -39,7 +40,7 @@ export interface IDnsQuery {
   dnsqueryGet: (req: Request, res: Response) => Promise<void>;
 }
 
-type conf = IConfigurationLogger & ICacheConfig;
+type conf = IConfigurationLogger & ICacheConfig & IConfigurationTon;
 
 export class DnsQuery implements IDnsQuery {
   _logger: ILoggerService;
@@ -115,7 +116,7 @@ export class DnsQuery implements IDnsQuery {
       punycodeDomainPartsToUnicode(dohDomain),
     );
 
-    const link = recordToDnslink(result.record);
+    const link = recordToDnslink(result.record, this._configurationService);
     if (!link) {
       return null;
     }
@@ -432,12 +433,21 @@ const trimTrailingSlashFromPath = (p: string) => {
   }
 };
 
-const recordToDnslink = (result: IRecord): string | null => {
+const recordToDnslink = (
+  result: IRecord,
+  config: IConfigurationTon,
+): string | null => {
   if (!result) {
     return null;
   } else if (result._tag === "ens-socials-redirect") {
     return null;
   } else if (result._tag === "Record") {
+    if (
+      result.codec === "adnl" &&
+      !config.getConfigTonBackend().getEnabled()
+    ) {
+      return null;
+    }
     const dnsLinkPrefix =
       result.codec === "arweave-ns"
         ? "ar://"

--- a/packages/dweb-api-server/src/dnsquery/index.ts
+++ b/packages/dweb-api-server/src/dnsquery/index.ts
@@ -441,7 +441,9 @@ const recordToDnslink = (result: IRecord): string | null => {
     const dnsLinkPrefix =
       result.codec === "arweave-ns"
         ? "ar://"
-        : `/${recordNamespaceToUrlHandlerMap[result.codec]}/`;
+        : result.codec === "adnl"
+          ? "adnl://"
+          : `/${recordNamespaceToUrlHandlerMap[result.codec]}/`;
     return `dnslink=${dnsLinkPrefix}${trimTrailingSlashFromPath(
       result.DoHContentIdentifier,
     )}`;

--- a/packages/dweb-api-server/src/test/integration.spec.ts
+++ b/packages/dweb-api-server/src/test/integration.spec.ts
@@ -850,6 +850,25 @@ describe("Proxy API Integration Tests", function () {
     );
     expect(content_storage_type).to.be.equal("arweave-ns");
   });
+
+  it("should resolve an ADNL (TON Site) contenthash to the adnl gateway subdomain", async () => {
+    const { content_location, content_path, content_storage_type, res } =
+      await commonSetup({
+        name: "tonnet.eth",
+        type: "adnl",
+        contentHash:
+          "adnl://61bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5",
+        additionalInfo: {},
+        options: populateDefaultOptions({}),
+      });
+
+    expect(res.statusCode).to.be.equal(200);
+    expect(content_location).to.be.equal(
+      "vq33bk5u3ah5di4qb7iqdbktjrheai47qvtjmxj3yzm2n77n5folewn.adnl:8080",
+    );
+    expect(content_path).to.be.equal("/");
+    expect(content_storage_type).to.be.equal("adnl");
+  });
 });
 
 describe("Caddy API Integration Tests", function () {
@@ -1265,6 +1284,26 @@ describe("DoH GET API Integration Tests", function () {
     expect(reply.name).to.equal("vitalik.jsonapi.eth");
     expect(reply.data).to.equal(
       "dnslink=/ipfs/bagaaiaf4af5se33lei5hi4tvmuwce5djnvsseorcge3timzqgy4dknzzeiwceytmn5rwwir2eizdemjtg42denjcfqrgk4tdei5dalbcovzwk4rchj5seylemrzgk43tei5cemdymq4giqjwijddenrzgy2gcrrziq3wkrlehfstam2fguztimjviqztoykbhe3danbveiwce3tbnvsseorcozuxiylmnfvs4zlunarcyitcmfwgc3tdmurduirvgizc4nrsgq2teobcfqrha4tjmnsseorcgiydenzogm4tenzugirh27i",
+    );
+    expect(reply.type).to.equal(16);
+  });
+
+  it("should produce an adnl:// dnslink for a TON (ADNL) contenthash", async () => {
+    const { _result } = await commonSetup({
+      name: "tonnet.eth",
+      type: "adnl",
+      additionalInfo: {},
+      contentHash:
+        "adnl://61bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5",
+      options: populateDefaultOptions({
+        dohQueryType: "TXT",
+      }),
+    });
+    const result = JSON.parse(_result);
+    const reply = result.Answer[0];
+    expect(reply.name).to.equal("tonnet.eth");
+    expect(reply.data).to.equal(
+      "dnslink=adnl://61bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5",
     );
     expect(reply.type).to.equal(16);
   });

--- a/packages/dweb-api-serviceworker/src/lib.ts
+++ b/packages/dweb-api-serviceworker/src/lib.ts
@@ -112,6 +112,7 @@ export const createConfig = (
     }),
     getConfigTonBackend: () => ({
       getBackend: () => "http://adnl:8080",
+      getEnabled: () => true,
     }),
     getConfigEnsSocialsEndpoint: () => ({
       getEnsSocialsEndpoint: null,

--- a/packages/dweb-api-serviceworker/src/lib.ts
+++ b/packages/dweb-api-serviceworker/src/lib.ts
@@ -7,6 +7,7 @@ import type {
   IConfigurationIpfs,
   IConfigurationLogger,
   IConfigurationSwarm,
+  IConfigurationTon,
 } from "dweb-api-types/config";
 import { JsonLoggerService } from "dweb-api-logger/jsonlogger";
 import {
@@ -35,6 +36,7 @@ export type ServiceWorkerConfig = IConfigurationLogger &
   IConfigurationIpfs &
   IConfigurationArweave &
   IConfigurationSwarm &
+  IConfigurationTon &
   IConfigurationEnsSocials & {
     verifiedFetch: boolean;
   };
@@ -107,6 +109,9 @@ export const createConfig = (
     }),
     getConfigSwarmBackend: () => ({
       getBackend: () => "https://api.gateway.ethswarm.org",
+    }),
+    getConfigTonBackend: () => ({
+      getBackend: () => "http://adnl:8080",
     }),
     getConfigEnsSocialsEndpoint: () => ({
       getEnsSocialsEndpoint: null,

--- a/packages/dweb-api-types/src/config.ts
+++ b/packages/dweb-api-types/src/config.ts
@@ -23,6 +23,12 @@ export interface IConfigurationSwarm {
   };
 }
 
+export interface IConfigurationTon {
+  getConfigTonBackend: () => {
+    getBackend: () => string;
+  };
+}
+
 export interface IConfigurationEthereum {
   getConfigEthereumBackend: () => {
     getBackend: () => string;

--- a/packages/dweb-api-types/src/config.ts
+++ b/packages/dweb-api-types/src/config.ts
@@ -26,6 +26,7 @@ export interface IConfigurationSwarm {
 export interface IConfigurationTon {
   getConfigTonBackend: () => {
     getBackend: () => string;
+    getEnabled: () => boolean;
   };
 }
 

--- a/packages/dweb-api-types/src/ens-resolver.ts
+++ b/packages/dweb-api-types/src/ens-resolver.ts
@@ -6,6 +6,7 @@ export const RECORD_CODEC_TYPE = z.enum([
   "ipns-ns",
   "arweave-ns",
   "swarm",
+  "adnl",
 ]);
 
 /*


### PR DESCRIPTION
## What

ENS names whose `contenthash` carries the `adnl` multicodec (`0xb69910`, a 32-byte TON ADNL address) now resolve to their TON Site, alongside IPFS/IPNS/Arweave/Swarm. The codec is already in `multiformats/multicodec` and `@ensdomains/content-hash` 3.1.0+, so this is an implementation change only.

## How

For an `adnl` record the API encodes the ADNL address as the 55 character base32 hostname used by TON tooling, which fits the 63 character DNS label limit, and returns:

```
X-Content-Location: <base32>.adnl
X-Content-Path: /
X-Content-Storage-Type: adnl
```

TON Sites are not reachable over plain HTTP, so the gateway reverse-proxies these to an RLDP-HTTP TON proxy (tonutils-proxy). The proxy routes on a Host ending in `.adnl`, so the decoded hostname is passed straight through as `Host` and served, with no re-resolution. The proxy address is set gateway-side via `TON_GATEWAY_HOST`, so the API needs no new config.

The generic `reverse_proxy {rp.header.X-Content-Location}` block cannot carry this one: it uses a single value as both the dial target and the `Host`, but the TON proxy needs a `Host` ending exactly in `.adnl` with no port. So a dedicated `handle_response` handler is added for `adnl`, leaving the existing handlers untouched. `*.adnl` site blocks mirror the IPFS and Swarm ones so the stack also works as a plain TON gateway.

## Changes

- `adnl` added to `RECORD_CODEC_TYPE`
- `parseRecord` decodes `adnl://`
- `recordToProxyRecord` routes `adnl` (base32 `.adnl` hostname into `X-Content-Location`)
- ADNL to base32 hostname encoder (`resolver/adnl.ts`)
- `adnl://` dnslink over DoH
- bump `@ensdomains/content-hash` 3.0.0 to 3.1.1 (adds the adnl profile)
- local_gateway: dedicated Caddy handler, `*.adnl` gateway blocks, `TON_GATEWAY_HOST`, commented tonutils-proxy service
- README

## Tests

New cases for the base32 encoder, the proxy record and the DoH dnslink. `npm test` passing, `npm run build-all` clean.
