### PR TITLE
fix: only include explicit TON_TARGET port in adnl X-Content-Location

### DIFF
--- a/packages/dweb-api-resolver/src/resolver/utils.ts
+++ b/packages/dweb-api-resolver/src/resolver/utils.ts
@@ -240,8 +240,6 @@ export const recordToProxyRecord = async (
       const backendString = tonConfig.getBackend();
       const url = new URL(backendString);
       url.hostname = `${hostname}.${url.hostname}`;
-      // Like the other backends, only include a port when TON_TARGET carries
-      // one explicitly; downstream proxies append their own default port
       const explicitPort = extractExplicitPort(backendString);
       return {
         ...record,

--- a/packages/dweb-api-resolver/src/resolver/utils.ts
+++ b/packages/dweb-api-resolver/src/resolver/utils.ts
@@ -240,9 +240,9 @@ export const recordToProxyRecord = async (
       const backendString = tonConfig.getBackend();
       const url = new URL(backendString);
       url.hostname = `${hostname}.${url.hostname}`;
-      const explicitPort =
-        extractExplicitPort(backendString) ||
-        (url.protocol === "https:" ? "443" : "80");
+      // Like the other backends, only include a port when TON_TARGET carries
+      // one explicitly; downstream proxies append their own default port
+      const explicitPort = extractExplicitPort(backendString);
       return {
         ...record,
         XContentLocation: constructUrlWithPort(url, explicitPort),

--- a/packages/dweb-api-server/src/test/integration.spec.ts
+++ b/packages/dweb-api-server/src/test/integration.spec.ts
@@ -869,6 +869,50 @@ describe("Proxy API Integration Tests", function () {
     expect(content_path).to.be.equal("/");
     expect(content_storage_type).to.be.equal("adnl");
   });
+
+  it("should not append a port for an ADNL contenthash when TON_TARGET has no explicit port", async () => {
+    harnessInput.configurationService.set((conf) => {
+      conf.ton.backend = "https://adnl.website";
+    });
+    const { content_location, content_path, content_storage_type, res } =
+      await commonSetup({
+        name: "tonnet.eth",
+        type: "adnl",
+        contentHash:
+          "adnl://61bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5",
+        additionalInfo: {},
+        options: populateDefaultOptions({}),
+      });
+
+    expect(res.statusCode).to.be.equal(200);
+    expect(content_location).to.be.equal(
+      "vq33bk5u3ah5di4qb7iqdbktjrheai47qvtjmxj3yzm2n77n5folewn.adnl.website",
+    );
+    expect(content_path).to.be.equal("/");
+    expect(content_storage_type).to.be.equal("adnl");
+  });
+
+  it("should preserve an explicit port for an ADNL contenthash when TON_TARGET has one", async () => {
+    harnessInput.configurationService.set((conf) => {
+      conf.ton.backend = "https://adnl.website:443";
+    });
+    const { content_location, content_path, content_storage_type, res } =
+      await commonSetup({
+        name: "tonnet.eth",
+        type: "adnl",
+        contentHash:
+          "adnl://61bd855da6c07e8d1c807e880c2a9a6272011cfc2b34b2e9de32cd37ff6f4ae5",
+        additionalInfo: {},
+        options: populateDefaultOptions({}),
+      });
+
+    expect(res.statusCode).to.be.equal(200);
+    expect(content_location).to.be.equal(
+      "vq33bk5u3ah5di4qb7iqdbktjrheai47qvtjmxj3yzm2n77n5folewn.adnl.website:443",
+    );
+    expect(content_path).to.be.equal("/");
+    expect(content_storage_type).to.be.equal("adnl");
+  });
 });
 
 describe("Caddy API Integration Tests", function () {


### PR DESCRIPTION
## What

Follow-up to #58. The `adnl` branch of `recordToProxyRecord` unconditionally appended a default port (`443` for https, `80` for http) to `X-Content-Location`, unlike every other storage backend, which only emits a port when the operator writes one into the `*_TARGET` variable explicitly.

## Why

Reverse proxy configs that append their own port to the header value (e.g. eth.limo's production `reverse_proxy {rp.header.X-Content-Location}:443`) produce a malformed `host:443:443` upstream for adnl records.

## How

Drop the default-port fallback and only preserve an explicit `TON_TARGET` port, matching the other backends. Two new integration tests cover the portless and explicit-port cases.

**Operator note:** local gateway deployments relying on the `:443` suffix for HTTPS upstream detection (`header X-Content-Location *:443` in `routes/dweb-proxy-api.Caddyfile`) must write the port explicitly, i.e. `TON_TARGET=https://host:443`. The compose default `http://adnl:8080` is unaffected. Verified end-to-end against a live TON site through the local gateway with `TON_TARGET=https://adnl.website:443`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)