### PR TITLE
feat: add direct Base L2 support for Basenames (*.base.eth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ __Gateway request flow__
 | `ETH_RPC_ENDPOINT` | `"http://192.168.1.7:8845"` | Primary RPC provider FQDN for ENS resolution. |
 | `ETH_RPC_ENDPOINT_FAILOVER_PRIMARY` | `null` | Secondary failover RPC provider FQDN. |
 | `GNO_RPC_ENDPOINT` |  `https://rpc.gnosischain.com` | Primary RPC endpoint for Gnosis. |
+| `BASE_RPC_ENDPOINT` | `https://mainnet.base.org` | Primary RPC endpoint for Base L2 (Basenames `*.base.eth` resolution). |
+| `BASE_L2_BYPASS_ENABLED` | `"true"` | Resolve `*.base.eth` contenthash records directly against the Basenames registry on Base L2, bypassing the Coinbase CCIP gateway (which does not serve contenthash records). Set to `false` to fall back to standard L1 ENS resolution. |
 | `DOMAINSAPI_ENDPOINT` | `null` | API endpoint for custom domain routing logic. Can be set to any endpoint that returns a `200` if you do not need this feature. |
 | `LOG_LEVEL` | `"info"` | Set the logging level. |
 | `LIMO_HOSTNAME_SUBSTITUTION_CONFIG` | `{ "eth.limo": "eth", "eth.local": "eth", "gno.limo": "gno", "gno.local": "gno" }` | The domains and services corresponding to each domain name for gateway operations. When set via an environment variable, this must be a base64 encoded JSON object. |

--- a/bin/integrationTests.sh
+++ b/bin/integrationTests.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+
+set -e
+
+IPFS_TESTS=(
+    "vitalik.eth"
+    "blockranger.eth"
+    "fast-ipfs.eth"
+    "ur.integration-tests.eth"
+)
+
+IPNS_TESTS=(
+    "kwenta.eth"
+)
+
+UNICODE_TESTS=(
+    "xn--wu9haa.eth"
+    "xn--wu9haa.eth.${DOMAIN_TLD}"
+    "subs.xn--wu9haa.eth"
+)
+
+ARWEAVE_TESTS=(
+    "makesy.eth"
+)
+
+ARNS_TESTS=(
+    "0xcatchup.eth"
+)
+
+SWARM_TESTS=(
+    "swarm.eth"
+)
+
+ART_TESTS=(
+    "limo.art"
+)
+
+GNOSIS_TESTS=(
+    "12345.gno"
+)
+
+# Basenames are resolved via the Basenames registry on Base L2. No known
+# *.base.eth name currently has a contenthash on its registry-assigned
+# resolver (existing records live on the superseded default L2Resolver and
+# are not honored); add names here once they exist.
+BASENAMES_TESTS=(
+)
+
+DOH_TESTS=(
+    "cigtoken.eth"
+    "weth.jsonapi.eth"
+)
+
+ASK_TESTS=(
+    "esteroids.eth"
+    "99re.eth.${DOMAIN_TLD}"
+)
+
+FAIL_ASK_TESTS=(
+    "proofofhumanity.eth.com"
+    "a.b.c.d.e.f.g.0xc0de4c0ffee.dev3.eth.${DOMAIN_TLD}"
+    "2607:f8b0:4009:804::200e"
+    "127.0.0.1"
+)
+
+BLACKLIST_TESTS=(
+    "officnewdriver.eth"
+)
+
+IPFS_FLATTEN_TESTS=(
+    "weth.jsonapi.eth"
+)
+
+NO_IPFS_FLATTEN_TESTS=(
+    "vitalik.eth"
+)
+
+DATAURI_TESTS=(
+    "singleparam.multiparam-weaken-home-truth-plan-9.eth"
+)
+
+DATAURL_TESTS=(
+    "redirect-0x55559E7da7AeC04B3156e16a60Cf57A348843dFB.eth"
+)
+
+apitest() {
+    printf "\n%s\n" "${1}"
+    printf "%s----------------\n" ""
+    status=$(curl http://127.0.0.1:8888 -H "Host: ${1}" -w %{http_code} -s -o /dev/null -H "X-Limo-Id: $(uuidgen)")
+    if [[ "${status}" != "${2}" ]]; then
+        printf "\nFAIL\n"
+        exit 1
+    else
+        printf "\nPASS\n"
+    fi
+}
+
+dohtest() {
+    printf "\n%s\n" "${1}"
+    printf "%s----------------\n" ""
+    if curl http://127.0.0.1:11000/dns-query\?name="${1}"\&type=TXT -s -H "X-Limo-Id: $(uuidgen)" | jq '.Answer[0].data' | grep 'dnslink=/ipfs/b' >/dev/null; then
+        printf "\nPASS\n"
+    else
+        printf "\nFAIL\n"
+        exit 1
+    fi
+}
+
+asktest() {
+    printf "\n%s\n" "${1}"
+    printf "%s----------------\n" ""
+    status=$(curl http://127.0.0.1:9090/ask\?domain="${1}" -w %{http_code} -o /dev/null -s -H "X-Limo-Id: $(uuidgen)")
+    if [[ "${status}" != "${2}" ]]; then
+        printf "\nFAIL\n"
+        exit 1
+    else
+        printf "\nPASS\n"
+    fi
+}
+
+flattentest() {
+    printf "\n%s\n" "${1}"
+    printf "%s----------------\n" ""
+    xcontent=$(curl http://127.0.0.1:8888 -H "Host: ${1}" -w '%header{X-Content-Location}' -s -o /dev/null -H "X-Limo-Id: $(uuidgen)")
+    flatten=$(echo "${xcontent}" | cut -d'.' -f1)
+    if [[ "${flatten}" != $(echo "${1}" | tr '.' '-') ]]; then
+        printf "\nFAIL\n"
+        exit 1
+    else
+        printf "\nPASS\n"
+    fi
+}
+
+noflattentest() {
+    printf "\n%s\n" "${1}"
+    printf "%s----------------\n" ""
+    if curl http://127.0.0.1:8888 -H "Host: ${1}" -w '%header{X-Content-Location}' -s -o /dev/null -H "X-Limo-Id: $(uuidgen)" | grep 'bafy' >/dev/null; then
+        printf "\nPASS\n"
+    else
+        printf "\nFAIL\n"
+        exit 1
+    fi
+}
+
+daturitest() {
+    printf "\n%s\n" "${1}"
+    printf "%s----------------\n" ""
+    datauri=$(curl http://127.0.0.1:8888 -H "Host: ${1}" -w '%header{X-Content-Path}' -s -o /dev/null -H "X-Limo-Id: $(uuidgen)")
+    if [[ "${datauri}" == "/api/v1/dataurl/${1}/"* ]]; then
+        printf "\nDATAURI LOCATION PASS\n"
+        status=$(curl http://localhost:12500"${datauri}" -w %{http_code} -s -o /dev/null -H "X-Limo-Id: $(uuidgen)" || true)
+        if [[ "${status}" != "${2}" ]]; then
+            printf "\nDATURI FETCH FAIL\n"
+            exit 1
+        else
+            printf "\nDATURI FETCH PASS\n"
+        fi
+    else
+        printf "\nDATAURI LOCATION FAIL\n"
+        exit 1
+    fi
+}
+
+daturltest() {
+    printf "\n%s\n" "${1}"
+    printf "%s----------------\n" ""
+    status=$(curl http://127.0.0.1:8888 -H "Host: ${1}" -w %{http_code} -s -o /dev/null -H "X-Limo-Id: $(uuidgen)")
+    if [[ "${status}" == "${2}" ]]; then
+        printf "\nDATAURL LOCATION PASS\n"
+        dataurl=$(curl http://127.0.0.1:8888 -H "Host: ${1}" -w %{http_code} -L -s -o /dev/null -H "X-Limo-Id: $(uuidgen)")
+        if [[ "${dataurl}" != "200" ]]; then
+            printf "\nDATURL FOLLOW FAIL\n"
+            exit 1
+        else
+            printf "\nDATURL FOLLOW PASS\n"
+        fi
+    else
+        printf "\nDATAURL LOCATION FAIL\n"
+        exit 1
+    fi
+}
+
+# Run tests for non-datauri services
+if [ "${ENABLE_DATAURI_TESTS}" != "true" ]; then
+    # IPFS
+    printf "\nRunning IPFS tests...\n"
+    for test in "${IPFS_TESTS[@]}"; do
+        apitest "${test}" "200"
+    done
+
+    # IPNS
+    printf "\nRunning IPNS tests...\n"
+    for test in "${IPNS_TESTS[@]}"; do
+        apitest "${test}" "200"
+    done
+
+    # Unicode
+    printf "\nRunning Unicode tests...\n"
+    for test in "${UNICODE_TESTS[@]}"; do
+        apitest "${test}" "200"
+    done
+
+    # Arweave
+    printf "\nRunning Arweave tests...\n"
+    for test in "${ARWEAVE_TESTS[@]}"; do
+        apitest "${test}" "200"
+    done
+
+    # ARNS
+    printf "\nRunning ARNS tests...\n"
+    for test in "${ARNS_TESTS[@]}"; do
+        apitest "${test}" "200"
+    done
+
+    # Swarm
+    printf "\nRunning Swarm tests...\n"
+    for test in "${SWARM_TESTS[@]}"; do
+        apitest "${test}" "200"
+    done
+
+    # Art
+    printf "\nRunning Art tests...\n"
+    for test in "${ART_TESTS[@]}"; do
+        apitest "${test}" "200"
+    done
+
+    # Gnosis
+    printf "\nRunning Gnosis tests...\n"
+    for test in "${GNOSIS_TESTS[@]}"; do
+        apitest "${test}" "200"
+    done
+
+    # Basenames
+    printf "\nRunning Basenames tests...\n"
+    for test in "${BASENAMES_TESTS[@]}"; do
+        apitest "${test}" "200"
+    done
+
+    # DoH
+    printf "\nRunning DoH tests...\n"
+    for test in "${DOH_TESTS[@]}"; do
+        dohtest "${test}" "200"
+    done
+
+    # Ask
+    printf "\nRunning Ask tests...\n"
+    for test in "${ASK_TESTS[@]}"; do
+        asktest "${test}" "200"
+    done
+
+    # Fail Ask
+    printf "\nRunning Ask tests that should fail...\n"
+    for test in "${FAIL_ASK_TESTS[@]}"; do
+        asktest "${test}" "422"
+    done
+
+    # Blacklist
+    printf "\nRunning Blacklist tests...\n"
+    for test in "${BLACKLIST_TESTS[@]}"; do
+        apitest "${test}" "451"
+    done
+
+    # Flatten tests
+    printf "\nRunning IPFS Flatten tests...\n"
+    for test in "${IPFS_FLATTEN_TESTS[@]}"; do
+        flattentest "${test}"
+    done
+
+    # DoH No-Flatten tests
+    printf "\nRunning DoH IPFS no Flatten tests...\n"
+    for test in "${IPFS_FLATTEN_TESTS[@]}"; do
+        dohtest "${test}"
+    done
+
+    # No-Flatten tests for IPFS
+    printf "\nRunning IPFS no Flatten tests...\n"
+    for test in "${NO_IPFS_FLATTEN_TESTS[@]}"; do
+        noflattentest "${test}"
+    done
+fi
+
+# Only run DataURI and DataURL tests if ENABLE_DATAURI_TESTS is true
+if [ "${ENABLE_DATAURI_TESTS}" = "true" ]; then
+    shopt -s nocasematch
+    # Data URI tests
+    printf "\nRunning DataURI tests...\n"
+    for test in "${DATAURI_TESTS[@]}"; do
+        daturitest "${test}" "200"
+    done
+
+    # Data URL tests
+    printf "\nRunning DataURL tests...\n"
+    for test in "${DATAURL_TESTS[@]}"; do
+        daturltest "${test}" "308"
+    done
+fi
+

--- a/packages/dweb-api-resolver/package.json
+++ b/packages/dweb-api-resolver/package.json
@@ -79,6 +79,10 @@
             "types": "./dist/nameservice/Web3NameSdkService.d.ts",
             "default": "./dist/nameservice/Web3NameSdkService.js"
         },
+        "./nameservice/BasenamesService": {
+            "types": "./dist/nameservice/BasenamesService.d.ts",
+            "default": "./dist/nameservice/BasenamesService.js"
+        },
         "./nameservice/utils": {
             "types": "./dist/nameservice/utils.d.ts",
             "default": "./dist/nameservice/utils.js"

--- a/packages/dweb-api-resolver/src/nameservice/BasenamesService.ts
+++ b/packages/dweb-api-resolver/src/nameservice/BasenamesService.ts
@@ -1,0 +1,102 @@
+import { Contract, JsonRpcProvider, ZeroAddress, namehash } from "ethers";
+import { ILoggerService } from "dweb-api-types/logger";
+import { IRequestContext } from "dweb-api-types/request-context";
+import {
+  DecodedCodecString,
+  DecodedDataUri,
+  DecodedDataUrl,
+  INameService,
+} from "dweb-api-types/name-service";
+import { IConfigurationBase } from "dweb-api-types/config";
+import { getContentHashFallback } from "./utils.js";
+
+const BASE_CHAIN_ID = 8453;
+/*
+  Basenames uses an ENS-style registry deployed on Base mainnet; each name's
+  resolver is looked up through it rather than hardcoding the default
+  L2Resolver so that names assigned a custom resolver still resolve.
+  https://github.com/base-org/basenames#deployments
+*/
+const BASENAMES_REGISTRY_ADDRESS = "0xB94704422c2a1E396835A571837Aa5AE53285a95";
+const REGISTRY_ABI = ["function resolver(bytes32 node) view returns (address)"];
+const RESOLVER_ABI = [
+  "function contenthash(bytes32 node) view returns (bytes)",
+];
+
+export class BasenamesService implements INameService {
+  _configurationService: IConfigurationBase;
+  provider: JsonRpcProvider;
+  registry: Contract;
+  _logger: ILoggerService;
+
+  constructor(
+    configurationService: IConfigurationBase,
+    logger: ILoggerService,
+  ) {
+    this._configurationService = configurationService;
+    const baseConfig = this._configurationService.getConfigBaseBackend();
+    const rpc = baseConfig.getBackend();
+
+    this.provider = new JsonRpcProvider(rpc, undefined, {
+      staticNetwork: true,
+    });
+    this.registry = new Contract(
+      BASENAMES_REGISTRY_ADDRESS,
+      REGISTRY_ABI,
+      this.provider,
+    );
+    this._logger = logger;
+  }
+
+  /*
+    RPC failures are deliberately not caught here: a thrown error propagates
+    to the resolver's failure path instead of being cached as "no record".
+  */
+  async getContentHash(
+    request: IRequestContext,
+    name: string,
+  ): Promise<DecodedCodecString | DecodedDataUri | DecodedDataUrl | null> {
+    const node = namehash(name);
+
+    const resolverAddress: string = await this.registry.resolver(node);
+    if (!resolverAddress || resolverAddress === ZeroAddress) {
+      this._logger.debug("BasenamesService: no resolver", {
+        ...request,
+        origin: "BasenamesService",
+        context: {
+          name,
+          node,
+        },
+      });
+      return null;
+    }
+
+    const resolver = new Contract(resolverAddress, RESOLVER_ABI, this.provider);
+    const contenthashBytes: string = await resolver.contenthash(node);
+
+    if (!contenthashBytes || contenthashBytes === "0x") {
+      this._logger.debug("BasenamesService: no contenthash set", {
+        ...request,
+        origin: "BasenamesService",
+        context: {
+          name,
+          node,
+          resolver: resolverAddress,
+        },
+      });
+      return null;
+    }
+
+    return getContentHashFallback(
+      request,
+      this._logger,
+      contenthashBytes,
+      name,
+      "BasenamesService",
+    );
+  }
+
+  getChainId(): number {
+    return BASE_CHAIN_ID;
+  }
+}

--- a/packages/dweb-api-resolver/src/nameservice/index.ts
+++ b/packages/dweb-api-resolver/src/nameservice/index.ts
@@ -1,9 +1,7 @@
 import { IRequestContext } from "dweb-api-types/request-context";
 import { ILoggerService } from "dweb-api-types/logger";
-import {
-  INameService,
-  INameServiceFactory,
-} from "dweb-api-types/name-service";
+import { INameService, INameServiceFactory } from "dweb-api-types/name-service";
+import { IConfigurationBase } from "dweb-api-types/config";
 export type Tag = "IEnsServiceError";
 export type ErrorType = "error";
 
@@ -11,15 +9,21 @@ export class NameServiceFactory implements INameServiceFactory {
   _logger: ILoggerService;
   _ensService: INameService;
   _web3NameSdkService: INameService;
+  _basenamesService: INameService | null;
+  _baseConfiguration: IConfigurationBase | null;
 
   constructor(
     logger: ILoggerService,
     ensService: INameService,
     web3NameSdkService: INameService,
+    basenamesService?: INameService | null,
+    baseConfiguration?: IConfigurationBase | null,
   ) {
     this._logger = logger;
     this._ensService = ensService;
     this._web3NameSdkService = web3NameSdkService;
+    this._basenamesService = basenamesService || null;
+    this._baseConfiguration = baseConfiguration || null;
   }
 
   getNameServiceForDomain(
@@ -32,6 +36,19 @@ export class NameServiceFactory implements INameServiceFactory {
         origin: "NameServiceFactory",
       });
       return this._web3NameSdkService;
+    }
+    if (
+      domain.endsWith(".base.eth") &&
+      this._basenamesService &&
+      (this._baseConfiguration
+        ? this._baseConfiguration.getConfigBaseBackend().getEnabled()
+        : true)
+    ) {
+      this._logger.debug("Using BasenamesService for domain " + domain, {
+        ...request,
+        origin: "NameServiceFactory",
+      });
+      return this._basenamesService;
     }
     this._logger.debug("Using EnsService for domain " + domain, {
       ...request,

--- a/packages/dweb-api-server/src/configuration/index.ts
+++ b/packages/dweb-api-server/src/configuration/index.ts
@@ -6,6 +6,7 @@ import type {
   IConfigurationEthereum,
   IConfigurationEthereumFailover,
   IConfigurationGnosis,
+  IConfigurationBase,
   ICacheConfig,
   IConfigurationIpfs,
   IConfigurationServerAsk,
@@ -54,6 +55,13 @@ const configuration = {
   },
   gnosis: {
     rpc: process.env.GNO_RPC_ENDPOINT || "https://rpc.gnosischain.com",
+  },
+  base: {
+    rpc: process.env.BASE_RPC_ENDPOINT || "https://mainnet.base.org",
+    //queries the Basenames registry on Base directly instead of L1 CCIP-read,
+    //working around the Coinbase gateway not serving contenthash records
+    l2BypassEnabled:
+      process.env.BASE_L2_BYPASS_ENABLED === "false" ? false : true,
   },
   // Storage backends
   ipfs: {
@@ -195,6 +203,8 @@ export class TestConfigurationService implements ServerConfiguration {
     this.configuration.arweave.backend = "https://arweave"; //arweave is never actually queried
     this.configuration.ton.backend = "http://adnl:8080"; //ton is never actually queried
     this.configuration.ton.enabled = true;
+    this.configuration.base.rpc = "http://base:69420"; //base is shimmed via TestResolverService
+    this.configuration.base.l2BypassEnabled = true;
     this.configuration.ens.socialsEndpoint = (ens: string) => {
       return `https://socials.com?name=${ens}`;
     };
@@ -248,6 +258,10 @@ export class TestConfigurationService implements ServerConfiguration {
 
   getConfigGnosisBackend = () => {
     return this.getServerConfiguration().getConfigGnosisBackend();
+  };
+
+  getConfigBaseBackend = () => {
+    return this.getServerConfiguration().getConfigBaseBackend();
   };
 
   getCacheConfig = () => {
@@ -430,6 +444,22 @@ export const configurationToIConfigurationGnosis = (config: {
     getConfigGnosisBackend: () => {
       return {
         getBackend: () => config.gnosis.rpc,
+      };
+    },
+  };
+};
+
+export const configurationToIConfigurationBase = (config: {
+  base: {
+    rpc: string;
+    l2BypassEnabled: boolean;
+  };
+}): IConfigurationBase => {
+  return {
+    getConfigBaseBackend: () => {
+      return {
+        getBackend: () => config.base.rpc,
+        getEnabled: () => config.base.l2BypassEnabled,
       };
     },
   };
@@ -695,6 +725,7 @@ export type ServerConfiguration = IConfigurationServerRouter &
   IConfigurationEthereum &
   IConfigurationEthereumFailover &
   IConfigurationGnosis &
+  IConfigurationBase &
   ICacheConfig &
   IConfigurationServerDnsquery &
   IDomainQueryConfig &
@@ -718,6 +749,7 @@ export const configurationToServerConfiguration = (
     ...configurationToIConfigurationEthereum(config),
     ...configurationToIConfigurationEthereumFailover(config),
     ...configurationToIConfigurationGnosis(config),
+    ...configurationToIConfigurationBase(config),
     ...configurationToICacheConfig(config),
     ...configurationToIDomainQueryConfig(config),
     ...configurationToIRedisConfig(config),

--- a/packages/dweb-api-server/src/dependencies/services.ts
+++ b/packages/dweb-api-server/src/dependencies/services.ts
@@ -24,10 +24,7 @@ import {
 } from "./BindingsManager.js";
 import type { ILoggerService } from "dweb-api-types/logger";
 import type { IRedisClient } from "dweb-api-types/redis";
-import type {
-  ICacheService,
-  INamedMemoryCache,
-} from "dweb-api-types/cache";
+import type { ICacheService, INamedMemoryCache } from "dweb-api-types/cache";
 import type { IKuboApiService } from "dweb-api-types/kubo-api";
 import type {
   IDataUrlResolverService,
@@ -50,6 +47,7 @@ import { TestLoggerService, LoggerService } from "dweb-api-logger";
 import { NameServiceFactory } from "dweb-api-resolver/nameservice";
 import { Web3NameSdkService } from "dweb-api-resolver/nameservice/Web3NameSdkService";
 import { EnsService } from "dweb-api-resolver/nameservice/EnsService";
+import { BasenamesService } from "dweb-api-resolver/nameservice/BasenamesService";
 
 export const createApplicationConfigurationBindingsManager = async () => {
   const configuration = new EnvironmentBinding<ServerConfiguration>({
@@ -196,6 +194,16 @@ export const createApplicationConfigurationBindingsManager = async () => {
       new TestResolverService(),
   });
 
+  const basenamesService = new EnvironmentBinding<INameService>({
+    [EnvironmentConfiguration.Production]: async (env) =>
+      new BasenamesService(
+        await configuration.getBinding(env),
+        await logger.getBinding(env),
+      ),
+    [EnvironmentConfiguration.Development]: async () =>
+      new TestResolverService(),
+  });
+
   const domainRateLimit = new EnvironmentBinding<IDomainRateLimitService>({
     [EnvironmentConfiguration.Production]: async (env) =>
       new DomainRateLimitService(
@@ -222,12 +230,16 @@ export const createApplicationConfigurationBindingsManager = async () => {
         await logger.getBinding(env),
         await ensService.getBinding(env),
         await web3NameSdk.getBinding(env),
+        await basenamesService.getBinding(env),
+        await configuration.getBinding(env),
       ),
     [EnvironmentConfiguration.Development]: async (env) =>
       new NameServiceFactory(
         await logger.getBinding(env),
         await ensService.getBinding(env),
         await web3NameSdk.getBinding(env),
+        await basenamesService.getBinding(env),
+        await configuration.getBinding(env),
       ),
   });
 
@@ -287,6 +299,7 @@ export const createApplicationConfigurationBindingsManager = async () => {
     kuboApi,
     web3NameSdk,
     ensService,
+    basenamesService,
     domainRateLimit,
     arweaveResolver,
     nameServiceFactory,

--- a/packages/dweb-api-server/src/test/cases.json
+++ b/packages/dweb-api-server/src/test/cases.json
@@ -82,5 +82,17 @@
     "type": "none",
     "contentHash": null,
     "additionalInfo": {}
+  },
+  {
+    "name": "example.base.eth",
+    "type": "ipfs",
+    "contentHash": "ipfs://bafkreibyh6otmd37y7edohwbjwydmqpxxygarmrur7j4xwhjejnskw3kta",
+    "additionalInfo": {}
+  },
+  {
+    "name": "norecord.base.eth",
+    "type": "none",
+    "contentHash": null,
+    "additionalInfo": {}
   }
 ]

--- a/packages/dweb-api-server/src/test/integration.spec.ts
+++ b/packages/dweb-api-server/src/test/integration.spec.ts
@@ -38,6 +38,7 @@ type HarnessType = {
   hostnameSubstitionService: IHostnameSubstitutionService;
   testEnsService: TestResolverService;
   web3NameSdkService: TestResolverService;
+  testBasenamesService: TestResolverService;
   testArweaveResolverService: TestResolverService;
   testDomainQuerySuperagentService: TestDomainQuerySuperagentService;
   domainQueryService: IDomainQueryService;
@@ -66,6 +67,9 @@ let buildAppContainer = async (): Promise<HarnessType> => {
       EnvironmentConfiguration.Development,
     )) as TestResolverService,
     web3NameSdkService: (await services.web3NameSdk.getBinding(
+      EnvironmentConfiguration.Development,
+    )) as TestResolverService,
+    testBasenamesService: (await services.basenamesService.getBinding(
       EnvironmentConfiguration.Development,
     )) as TestResolverService,
     testArweaveResolverService: (await services.arweaveResolver.getBinding(
@@ -223,11 +227,17 @@ const harness =
     const resolvers = [
       harnessInput.testEnsService,
       harnessInput.web3NameSdkService,
+      harnessInput.testBasenamesService,
     ];
 
     var theRealTestResolverService: TestResolverService;
 
-    if (nameResolvedToEnsName.endsWith("eth")) {
+    if (
+      nameResolvedToEnsName.endsWith(".base.eth") &&
+      harnessInput.configurationService.getConfigBaseBackend().getEnabled()
+    ) {
+      theRealTestResolverService = harnessInput.testBasenamesService;
+    } else if (nameResolvedToEnsName.endsWith("eth")) {
       theRealTestResolverService = harnessInput.testEnsService;
     } else if (nameResolvedToEnsName.endsWith("gno")) {
       theRealTestResolverService = harnessInput.web3NameSdkService;
@@ -868,6 +878,47 @@ describe("Proxy API Integration Tests", function () {
     );
     expect(content_path).to.be.equal("/");
     expect(content_storage_type).to.be.equal("adnl");
+  });
+
+  it("should resolve a Basename (*.base.eth) via the Basenames service", async () => {
+    const { content_location, content_storage_type, res } = await commonSetup({
+      name: "example.base.eth",
+      type: "ipfs",
+      contentHash:
+        "ipfs://bafkreibyh6otmd37y7edohwbjwydmqpxxygarmrur7j4xwhjejnskw3kta",
+      additionalInfo: {},
+      options: populateDefaultOptions({}),
+    });
+
+    expect(res.statusCode).to.be.equal(200);
+    expect(content_location).to.contain(
+      "bafkreibyh6otmd37y7edohwbjwydmqpxxygarmrur7j4xwhjejnskw3kta",
+    );
+    expect(content_storage_type).to.be.equal("ipfs-ns");
+  });
+
+  it("should fall back to L1 ENS resolution for *.base.eth when BASE_L2_BYPASS_ENABLED is false", async () => {
+    harnessInput.configurationService.set((conf) => {
+      conf.base.l2BypassEnabled = false;
+    });
+
+    //with the bypass disabled, the harness expects EnsService to serve this
+    //name; the Basenames test resolver is left poisoned (unset), so a 200
+    //here proves the factory routed around it
+    const { content_location, content_storage_type, res } = await commonSetup({
+      name: "example.base.eth",
+      type: "ipfs",
+      contentHash:
+        "ipfs://bafkreibyh6otmd37y7edohwbjwydmqpxxygarmrur7j4xwhjejnskw3kta",
+      additionalInfo: {},
+      options: populateDefaultOptions({}),
+    });
+
+    expect(res.statusCode).to.be.equal(200);
+    expect(content_location).to.contain(
+      "bafkreibyh6otmd37y7edohwbjwydmqpxxygarmrur7j4xwhjejnskw3kta",
+    );
+    expect(content_storage_type).to.be.equal("ipfs-ns");
   });
 });
 

--- a/packages/dweb-api-types/src/config.ts
+++ b/packages/dweb-api-types/src/config.ts
@@ -53,6 +53,13 @@ export interface IConfigurationGnosis {
   };
 }
 
+export interface IConfigurationBase {
+  getConfigBaseBackend: () => {
+    getBackend: () => string;
+    getEnabled: () => boolean;
+  };
+}
+
 export type IConfigurationLogger = {
   getLoggerConfig: () => {
     getLevel: () => "warn" | "error" | "info" | "debug";


### PR DESCRIPTION
Supersedes #20 — rewritten on top of current `main`, preserving @vickcharles's authorship on the commit.

## Summary
Resolves contenthash records for Basenames (`*.base.eth`) by querying the Basenames registry on Base L2 directly, bypassing the Coinbase CCIP gateway which does not serve contenthash records.

## Changes vs #20
The original PR predates the ENSv2 refactor (#52) and no longer compiled against `main` (stale `INameService` signature, `dist/` imports, missing `getChainId()`, un-awaited `getContentHashFallback`). Beyond the rebase:

- **Registry lookup**: `BasenamesService` queries the Basenames registry (`0xB94704422c2a1E396835A571837Aa5AE53285a95`) for the name's assigned resolver via `resolver(namehash(name))`, then reads `contenthash` from it.
- **`BASE_L2_BYPASS_ENABLED` flag (default `true`)**: checked at request time in `NameServiceFactory`; when `false`, `*.base.eth` falls back to standard L1 ENS resolution.
- **`BASE_RPC_ENDPOINT`** (default `https://mainnet.base.org`) via a new `IConfigurationBase` interface, following the repo's configuration conventions.
- **Errors are not swallowed**: RPC failures propagate to the resolver's failure path instead of being returned as `null` (which would have been cached as a negative "no record" result). Zero-address resolver / empty `0x` contenthash still return `null` as genuine no-record cases.
- `getNameServiceForCointype` is intentionally untouched (no in-repo callers).

## Test plan
- [x] Two new `cases.json` entries (`example.base.eth`, `norecord.base.eth`) run through the full permutation matrix with a dedicated Basenames test resolver in the harness
- [x] Explicit test: Basename resolves via the Basenames service
- [x] Explicit test: with `BASE_L2_BYPASS_ENABLED=false`, `*.base.eth` falls back to L1 ENS (Basenames resolver left poisoned to prove routing)
- [x] All 2737 server + 54 resolver tests pass
- [x] Live integration test script ported from dweb-api (`bin/integrationTests.sh`) with an empty Basenames scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)
